### PR TITLE
Add API methods for recently updated/created contacts

### DIFF
--- a/HubSpot.NET.Examples/Contacts.cs
+++ b/HubSpot.NET.Examples/Contacts.cs
@@ -16,7 +16,7 @@ namespace HubSpot.NET.Examples
              * Initialize the API with your API Key
              * You can find or generate this under Integrations -> HubSpot API key
              */
-            var api = new HubSpotApi("YOUR-API-KEY-HERE");
+            var api = new HubSpotApi("demo");
 
             /**
              * Create a contact
@@ -85,6 +85,22 @@ namespace HubSpot.NET.Examples
              */
             var contacts = api.Contact.List<ContactHubSpotModel>(
                 new ListRequestOptions { PropertiesToInclude = new List<string> { "firstname", "lastname", "email" } });
+
+            /**
+             * Get the most recently updated contacts, limited to 10
+             */
+            var recentlyUpdated = api.Contact.RecentlyUpdated<ContactHubSpotModel>(new ListRecentRequestOptions()
+            {
+                Limit = 10
+            });
+
+            /**
+             * Get the most recently created contacts, limited to 10
+             */
+            var recentlyCreated = api.Contact.RecentlyCreated<ContactHubSpotModel>(new ListRecentRequestOptions()
+            {
+                Limit = 10
+            });
         }
     }
 }

--- a/HubSpot.NET.Examples/Contacts.cs
+++ b/HubSpot.NET.Examples/Contacts.cs
@@ -16,7 +16,7 @@ namespace HubSpot.NET.Examples
              * Initialize the API with your API Key
              * You can find or generate this under Integrations -> HubSpot API key
              */
-            var api = new HubSpotApi("demo");
+            var api = new HubSpotApi("YOUR-API-KEY-HERE");
 
             /**
              * Create a contact

--- a/HubSpot.NET/Api/Contact/Dto/ListRecentRequestOptions.cs
+++ b/HubSpot.NET/Api/Contact/Dto/ListRecentRequestOptions.cs
@@ -1,0 +1,30 @@
+﻿using HubSpot.NET.Core;
+
+namespace HubSpot.NET.Api.Contact.Dto
+{
+    /// <summary>
+    /// Options used when querying for lists of items.
+    /// </summary>
+    public class ListRecentRequestOptions : ListRequestOptions
+    {
+        /// <summary>
+        /// Used for pagination
+        /// </summary>
+        public string TimeOffset { get; set; }
+
+        /// <summary>
+        /// Specififes if the current value for a property should be fetched or all historical values
+        /// </summary>
+        public string PropertyMode { get; set; } = "value_only";
+
+        /// <summary>
+        /// Specifies if all/none/newest/oldest form submissions should be fetched
+        /// </summary>
+        public string FormSubmissionMode { get; set; } = "newest";
+
+        /// <summary>
+        /// Whether to retrieve current list memberships for the contacts
+        /// </summary>
+        public bool ShowListMemberships { get; set; } = false;
+    }
+}

--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -129,5 +129,89 @@ namespace HubSpot.NET.Api.Contact
 
             _client.ExecuteBatch(path, contacts.Select(c => (object) c).ToList(), Method.POST);
         }
+
+        /// <summary>
+        /// Get recently updated (or created) contacts
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="opts">Request options</param>
+        /// <returns></returns>
+        public ContactListHubSpotModel<T> RecentlyUpdated<T>(ListRecentRequestOptions opts = null) where T : ContactHubSpotModel, new()
+        {
+            if (opts == null)
+            {
+                opts = new ListRecentRequestOptions();
+            }
+
+            var path = $"{new ContactHubSpotModel().RouteBasePath}/lists/recently_updated/contacts/recent"
+                .SetQueryParam("count", opts.Limit);
+
+            if (opts.PropertiesToInclude.Any())
+            {
+                path.SetQueryParam("property", opts.PropertiesToInclude);
+            }
+
+            if (opts.Offset.HasValue)
+            {
+                path = path.SetQueryParam("vidOffset", opts.Offset);
+            }
+
+            if (!string.IsNullOrEmpty(opts.TimeOffset))
+            {
+                path = path.SetQueryParam("timeOffset", opts.TimeOffset);
+            }
+            
+            path = path.SetQueryParam("propertyMode", opts.PropertyMode);
+            
+            path = path.SetQueryParam("formSubmissionMode", opts.FormSubmissionMode);
+            
+            path = path.SetQueryParam("showListMemberships", opts.ShowListMemberships);
+            
+            var data = _client.ExecuteList<ContactListHubSpotModel<T>>(path, opts);
+
+            return data;
+        }
+
+        /// <summary>
+        /// Get a list of recently created contacts
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="opts">Request options</param>
+        /// <returns></returns>
+        public ContactListHubSpotModel<T> RecentlyCreated<T>(ListRecentRequestOptions opts = null) where T : ContactHubSpotModel, new()
+        {
+            if (opts == null)
+            {
+                opts = new ListRecentRequestOptions();
+            }
+
+            var path = $"{new ContactHubSpotModel().RouteBasePath}/lists/all/contacts/recent"
+                .SetQueryParam("count", opts.Limit);
+
+            if (opts.PropertiesToInclude.Any())
+            {
+                path.SetQueryParam("property", opts.PropertiesToInclude);
+            }
+
+            if (opts.Offset.HasValue)
+            {
+                path = path.SetQueryParam("vidOffset", opts.Offset);
+            }
+
+            if (!string.IsNullOrEmpty(opts.TimeOffset))
+            {
+                path = path.SetQueryParam("timeOffset", opts.TimeOffset);
+            }
+            
+            path = path.SetQueryParam("propertyMode", opts.PropertyMode);
+            
+            path = path.SetQueryParam("formSubmissionMode", opts.FormSubmissionMode);
+            
+            path = path.SetQueryParam("showListMemberships", opts.ShowListMemberships);
+            
+            var data = _client.ExecuteList<ContactListHubSpotModel<T>>(path, opts);
+
+            return data;
+        }
     }
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotContactApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotContactApi.cs
@@ -13,5 +13,7 @@ namespace HubSpot.NET.Core.Interfaces
         T GetById<T>(long contactId) where T : ContactHubSpotModel, new();
         ContactListHubSpotModel<T> List<T>(ListRequestOptions opts = null) where T : ContactHubSpotModel, new();
         void Update<T>(T contact) where T : ContactHubSpotModel, new();
+        ContactListHubSpotModel<T> RecentlyCreated<T>(ListRecentRequestOptions opts = null) where T : ContactHubSpotModel, new();
+        ContactListHubSpotModel<T> RecentlyUpdated<T>(ListRecentRequestOptions opts = null) where T : ContactHubSpotModel, new();
     }
 }


### PR DESCRIPTION
This fixes #11. Adds two new contact API methods for retrieving recently updated and created contacts.