### PR TITLE
Recent deals

### DIFF
--- a/HubSpot.NET.Examples/Deals.cs
+++ b/HubSpot.NET.Examples/Deals.cs
@@ -1,5 +1,6 @@
 ﻿using HubSpot.NET.Api.Deal.Dto;
 using HubSpot.NET.Core;
+using System;
 using System.Collections.Generic;
 
 namespace HubSpot.NET.Examples
@@ -36,7 +37,7 @@ namespace HubSpot.NET.Examples
 
             /**
              *  Get all deals
-             *  This is commented in case the data has a large quantity of deals in HubSpot.
+             *  This is commented in case the HubSpot data has a large quantity of deals.
              */
             //var moreResults = true;
             //long offset = 0;
@@ -50,23 +51,28 @@ namespace HubSpot.NET.Examples
             //}
 
             /**
-             *  Get recently created deals, limited to 10 records
+             *  Get recently created deals since 7 days ago, limited to 10 records
              *  Using DealRecentListHubSpotModel to accomodate deals returning in the "results" property.
              */
+            var currentdatetime = DateTime.SpecifyKind(DateTime.Now.AddDays(-7), DateTimeKind.Utc);
+            var since = ((DateTimeOffset)currentdatetime).ToUnixTimeMilliseconds().ToString();
+
             var recentlyCreatedDeals = api.Deal.RecentlyCreated<DealHubSpotModel>(new DealRecentRequestOptions
             {
                 Limit = 10,
                 IncludePropertyVersion = false,
+                Since = since
             });
 
             /**
-             *  Get recently created deals, limited to 10 records
+             *  Get recently created deals since 7 days ago, limited to 10 records
              *  Using DealRecentListHubSpotModel to accomodate deals returning in the "results" property.
              */
             var recentlyUpdatedDeals = api.Deal.RecentlyCreated<DealHubSpotModel>(new DealRecentRequestOptions
             {
                 Limit = 10,
                 IncludePropertyVersion = false,
+                Since = since
             });
         }
     }

--- a/HubSpot.NET.Examples/Deals.cs
+++ b/HubSpot.NET.Examples/Deals.cs
@@ -52,6 +52,7 @@ namespace HubSpot.NET.Examples
 
             /**
              *  Get recently created deals since 7 days ago, limited to 10 records
+             *  Will default to 30 day if Since is not set.
              *  Using DealRecentListHubSpotModel to accomodate deals returning in the "results" property.
              */
             var currentdatetime = DateTime.SpecifyKind(DateTime.Now.AddDays(-7), DateTimeKind.Utc);
@@ -66,6 +67,7 @@ namespace HubSpot.NET.Examples
 
             /**
              *  Get recently created deals since 7 days ago, limited to 10 records
+             *  Will default to 30 day if Since is not set.
              *  Using DealRecentListHubSpotModel to accomodate deals returning in the "results" property.
              */
             var recentlyUpdatedDeals = api.Deal.RecentlyCreated<DealHubSpotModel>(new DealRecentRequestOptions

--- a/HubSpot.NET.Examples/Deals.cs
+++ b/HubSpot.NET.Examples/Deals.cs
@@ -36,6 +36,7 @@ namespace HubSpot.NET.Examples
 
             /**
              *  Get all deals
+             *  This is commented in case the data has a large quantity of deals in HubSpot.
              */
             //var moreResults = true;
             //long offset = 0;
@@ -46,8 +47,27 @@ namespace HubSpot.NET.Examples
 
             //    moreResults = allDeals.MoreResultsAvailable;
             //    if (moreResults) offset = allDeals.ContinuationOffset;
-
             //}
+
+            /**
+             *  Get recently created deals, limited to 10 records
+             *  Using DealRecentListHubSpotModel to accomodate deals returning in the "results" property.
+             */
+            var recentlyCreatedDeals = api.Deal.RecentlyCreated<DealHubSpotModel>(new DealRecentRequestOptions
+            {
+                Limit = 10,
+                IncludePropertyVersion = false,
+            });
+
+            /**
+             *  Get recently created deals, limited to 10 records
+             *  Using DealRecentListHubSpotModel to accomodate deals returning in the "results" property.
+             */
+            var recentlyUpdatedDeals = api.Deal.RecentlyCreated<DealHubSpotModel>(new DealRecentRequestOptions
+            {
+                Limit = 10,
+                IncludePropertyVersion = false,
+            });
         }
     }
 }

--- a/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
+++ b/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
@@ -119,5 +119,66 @@ namespace HubSpot.NET.Api.Company
 
             _client.Execute(path, method: Method.DELETE);
         }
+
+        public DealRecentListHubSpotModel<T> RecentlyCreated<T>(DealRecentRequestOptions opts = null) where T : DealHubSpotModel, new()
+        {
+
+            if (opts == null)
+            {
+                opts = new DealRecentRequestOptions();
+            }
+
+            var path = $"{new DealRecentListHubSpotModel<T>().RouteBasePath}/deal/recent/created"
+                .SetQueryParam("limit", opts.Limit);
+
+            if (opts.Offset.HasValue)
+            {
+                path = path.SetQueryParam("offset", opts.Offset);
+            }
+
+            if (opts.IncludePropertyVersion)
+            {
+                path = path.SetQueryParam("includePropertyVersions", "true");
+            }
+
+            if (!string.IsNullOrEmpty(opts.Since))
+            {
+                path = path.SetQueryParam("since", opts.Since);
+            }
+
+            var data = _client.ExecuteList<DealRecentListHubSpotModel<T>>(path, opts);
+
+            return data;
+        }
+
+        public DealRecentListHubSpotModel<T> RecentlyUpdated<T>(DealRecentRequestOptions opts = null) where T : DealHubSpotModel, new()
+        {
+            if (opts == null)
+            {
+                opts = new DealRecentRequestOptions();
+            }
+
+            var path = $"{new DealRecentListHubSpotModel<T>().RouteBasePath}/deal/recent/modified"
+                .SetQueryParam("limit", opts.Limit);
+
+            if (opts.Offset.HasValue)
+            {
+                path = path.SetQueryParam("offset", opts.Offset);
+            }
+
+            if (opts.IncludePropertyVersion)
+            {
+                path = path.SetQueryParam("includePropertyVersions", "true");
+            }
+
+            if (!string.IsNullOrEmpty(opts.Since))
+            {
+                path = path.SetQueryParam("since", opts.Since);
+            }
+
+            var data = _client.ExecuteList<DealRecentListHubSpotModel<T>>(path, opts);
+
+            return data;
+        }
     }
 }

--- a/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
+++ b/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
@@ -119,66 +119,6 @@ namespace HubSpot.NET.Api.Company
 
             _client.Execute(path, method: Method.DELETE);
         }
-
-        public DealRecentListHubSpotModel<T> RecentlyCreated<T>(DealRecentRequestOptions opts = null) where T : DealHubSpotModel, new()
-        {
-
-            if (opts == null)
-            {
-                opts = new DealRecentRequestOptions();
-            }
-
-            var path = $"{new DealRecentListHubSpotModel<T>().RouteBasePath}/deal/recent/created"
-                .SetQueryParam("limit", opts.Limit);
-
-            if (opts.Offset.HasValue)
-            {
-                path = path.SetQueryParam("offset", opts.Offset);
-            }
-
-            if (opts.IncludePropertyVersion)
-            {
-                path = path.SetQueryParam("includePropertyVersions", "true");
-            }
-
-            if (!string.IsNullOrEmpty(opts.Since))
-            {
-                path = path.SetQueryParam("since", opts.Since);
-            }
-
-            var data = _client.ExecuteList<DealRecentListHubSpotModel<T>>(path, opts);
-
-            return data;
-        }
-
-        public DealRecentListHubSpotModel<T> RecentlyUpdated<T>(DealRecentRequestOptions opts = null) where T : DealHubSpotModel, new()
-        {
-            if (opts == null)
-            {
-                opts = new DealRecentRequestOptions();
-            }
-
-            var path = $"{new DealRecentListHubSpotModel<T>().RouteBasePath}/deal/recent/modified"
-                .SetQueryParam("limit", opts.Limit);
-
-            if (opts.Offset.HasValue)
-            {
-                path = path.SetQueryParam("offset", opts.Offset);
-            }
-
-            if (opts.IncludePropertyVersion)
-            {
-                path = path.SetQueryParam("includePropertyVersions", "true");
-            }
-
-            if (!string.IsNullOrEmpty(opts.Since))
-            {
-                path = path.SetQueryParam("since", opts.Since);
-            }
-
-            var data = _client.ExecuteList<DealRecentListHubSpotModel<T>>(path, opts);
-
-            return data;
-        }
+               
     }
 }

--- a/HubSpot.NET/Api/Deal/Dto/DealRecentListHubSpotModel.cs
+++ b/HubSpot.NET/Api/Deal/Dto/DealRecentListHubSpotModel.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace HubSpot.NET.Api.Deal.Dto
+{
+    /// <summary>
+    /// Models a set of results returned when querying for sets of recently created or modified deals
+    /// </summary>
+    /// <remarks>
+    /// The sole reason for this class is because HubSpot uses a different property when returning 
+    /// recently created or modified deals versus all deals.
+    /// 
+    /// With retrieving all deals the deals are returned in the property "deals".
+    /// With recent deals the deals are returned in the property "results".
+    /// </remarks>
+    public class DealRecentListHubSpotModel<T> : DealListHubSpotModel<T> where T : DealHubSpotModel, new()
+    {
+        /// <summary>
+        /// Gets or sets the deals.
+        /// </summary>
+        /// <value>
+        /// The list of deals.
+        /// </value>
+        [DataMember(Name = "results")]
+        public new IList<T> Deals { get; set; } = new List<T>();
+
+    }
+}

--- a/HubSpot.NET/Api/Deal/Dto/DealRecentRequestOptions.cs
+++ b/HubSpot.NET/Api/Deal/Dto/DealRecentRequestOptions.cs
@@ -1,0 +1,22 @@
+﻿using HubSpot.NET.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HubSpot.NET.Api.Deal.Dto
+{
+    public class DealRecentRequestOptions : ListRequestOptions
+    {
+        /// <summary>
+        /// Used to specify the oldest timestamp to use to retrieve deals
+        /// </summary>
+        public string Since { get; set; }
+
+        /// <summary>
+        /// Specififes if the current value for a property should be fetched or all historical values
+        /// </summary>
+        public bool IncludePropertyVersion { get; set; } = false;
+    }
+}

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -109,5 +109,78 @@ namespace HubSpot.NET.Api.Deal
 
             _client.Execute(path, method: Method.DELETE);
         }
+
+        /// <summary>
+        /// Gets a list of recently created deals
+        /// </summary>
+        /// <typeparam name="T">Implementation of DealListHubSpotModel</typeparam>
+        /// <param name="opts">Options (limit, offset) relating to request</param>
+        /// <returns>List of deals</returns>
+        public DealRecentListHubSpotModel<T> RecentlyCreated<T>(DealRecentRequestOptions opts = null) where T : DealHubSpotModel, new()
+        {
+
+            if (opts == null)
+            {
+                opts = new DealRecentRequestOptions();
+            }
+
+            var path = $"{new DealRecentListHubSpotModel<T>().RouteBasePath}/deal/recent/created"
+                .SetQueryParam("limit", opts.Limit);
+
+            if (opts.Offset.HasValue)
+            {
+                path = path.SetQueryParam("offset", opts.Offset);
+            }
+
+            if (opts.IncludePropertyVersion)
+            {
+                path = path.SetQueryParam("includePropertyVersions", "true");
+            }
+
+            if (!string.IsNullOrEmpty(opts.Since))
+            {
+                path = path.SetQueryParam("since", opts.Since);
+            }
+
+            var data = _client.ExecuteList<DealRecentListHubSpotModel<T>>(path, opts);
+
+            return data;
+        }
+
+        /// <summary>
+        /// Gets a list of recently modified deals
+        /// </summary>
+        /// <typeparam name="T">Implementation of DealListHubSpotModel</typeparam>
+        /// <param name="opts">Options (limit, offset) relating to request</param>
+        /// <returns>List of deals</returns>
+        public DealRecentListHubSpotModel<T> RecentlyUpdated<T>(DealRecentRequestOptions opts = null) where T : DealHubSpotModel, new()
+        {
+            if (opts == null)
+            {
+                opts = new DealRecentRequestOptions();
+            }
+
+            var path = $"{new DealRecentListHubSpotModel<T>().RouteBasePath}/deal/recent/modified"
+                .SetQueryParam("limit", opts.Limit);
+
+            if (opts.Offset.HasValue)
+            {
+                path = path.SetQueryParam("offset", opts.Offset);
+            }
+
+            if (opts.IncludePropertyVersion)
+            {
+                path = path.SetQueryParam("includePropertyVersions", "true");
+            }
+
+            if (!string.IsNullOrEmpty(opts.Since))
+            {
+                path = path.SetQueryParam("since", opts.Since);
+            }
+
+            var data = _client.ExecuteList<DealRecentListHubSpotModel<T>>(path, opts);
+
+            return data;
+        }
     }
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotDealApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotDealApi.cs
@@ -12,5 +12,11 @@ namespace HubSpot.NET.Core.Interfaces
 
         DealListHubSpotModel<T> List<T>(bool includeAssociations, ListRequestOptions opts = null)
             where T : DealHubSpotModel, new();
+
+        DealRecentListHubSpotModel<T> RecentlyCreated<T>(DealRecentRequestOptions opts = null)
+            where T : DealHubSpotModel, new();
+
+        DealRecentListHubSpotModel<T> RecentlyUpdated<T>(DealRecentRequestOptions opts = null)
+            where T : DealHubSpotModel, new();
     }
 }


### PR DESCRIPTION
- Methods added to the Deals API class for recently created and recently modified deals
- Using a derived class as a return type for these two method calls due to a different DataMember name property for the deals list
- Example code added to Deals class