### PR TITLE
Add Create Update Method to Contact API

### DIFF
--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -32,6 +32,18 @@ namespace HubSpot.NET.Api.Contact
         }
 
         /// <summary>
+        /// Creates or Updates a contact entity based on the Entity Email
+        /// </summary>
+        /// <typeparam name="T">Implementation of ContactHubSpotModel</typeparam>
+        /// <param name="entity">The entity</param>
+        /// <returns>The created entity (with ID set)</returns>
+        public T CreateOrUpdate<T>(T entity) where T : ContactHubSpotModel, new()
+        {
+            var path = $"{entity.RouteBasePath}/contact/createOrUpdate/email/{entity.Email}/";
+            return _client.Execute<T>(path, entity, Method.POST);
+        }
+
+        /// <summary>
         /// Gets a single contact by ID from hubspot
         /// </summary>
         /// <param name="contactId">ID of the contact</param>

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -109,7 +109,7 @@ namespace HubSpot.NET.Api.Deal
         /// <param name="objectName">String name of Hubspot object related to deals (contact\account)</param>
         /// <param name="opts">Options (limit, offset) relating to request</param>
         /// <returns>List of deals</returns>
-        public DealListHubSpotModel<T> AssociatedList<T>(bool includeAssociations, long hubId, ListRequestOptions opts = null, string objectName = "contact") where T : DealHubSpotModel, new()
+        public DealListHubSpotModel<T> ListAssociated<T>(bool includeAssociations, long hubId, ListRequestOptions opts = null, string objectName = "contact") where T : DealHubSpotModel, new()
         {
             if (opts == null)
             {

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -99,6 +99,46 @@ namespace HubSpot.NET.Api.Deal
             return data;
         }
 
+
+        /// <summary>
+        /// Gets a list of deals associated to a hubSpot Object
+        /// </summary>
+        /// <typeparam name="T">Implementation of DealListHubSpotModel</typeparam>
+        /// <param name="includeAssociations">Bool include associated Ids</param>
+        /// <param name="hubId">Long Id of Hubspot object related to deals</param>
+        /// <param name="objectName">String name of Hubspot object related to deals (contact\account)</param>
+        /// <param name="opts">Options (limit, offset) relating to request</param>
+        /// <returns>List of deals</returns>
+        public DealListHubSpotModel<T> AssociatedList<T>(bool includeAssociations, long hubId, ListRequestOptions opts = null, string objectName = "contact") where T : DealHubSpotModel, new()
+        {
+            if (opts == null)
+            {
+                opts = new ListRequestOptions();
+            }
+
+            var path = $"{new DealListHubSpotModel<T>().RouteBasePath}/deal/associated/{objectName}/{hubId}/paged"
+                .SetQueryParam("limit", opts.Limit);
+
+            if (opts.Offset.HasValue)
+            {
+                path = path.SetQueryParam("offset", opts.Offset);
+            }
+
+            if (includeAssociations)
+            {
+                path = path.SetQueryParam("includeAssociations", "true");
+            }
+
+            if (opts.PropertiesToInclude.Any())
+            {
+                path = path.SetQueryParam("properties", opts.PropertiesToInclude);
+            }
+
+            var data = _client.ExecuteList<DealListHubSpotModel<T>>(path, opts);
+
+            return data;
+        }
+
         /// <summary>
         /// Deletes a given deal (by ID)
         /// </summary>

--- a/HubSpot.NET/Core/Interfaces/IHubSpotContactApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotContactApi.cs
@@ -7,6 +7,7 @@ namespace HubSpot.NET.Core.Interfaces
     public interface IHubSpotContactApi
     {
         T Create<T>(T entity) where T : ContactHubSpotModel, new();
+        T CreateOrUpdate<T>(T entity) where T : ContactHubSpotModel, new();
         void Delete(long contactId);
         void Batch<T>(List<T> entities) where T : ContactHubSpotModel, new();
         T GetByEmail<T>(string email) where T : ContactHubSpotModel, new();

--- a/HubSpot.NET/Core/Interfaces/IHubSpotDealApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotDealApi.cs
@@ -18,5 +18,6 @@ namespace HubSpot.NET.Core.Interfaces
 
         DealRecentListHubSpotModel<T> RecentlyUpdated<T>(DealRecentRequestOptions opts = null)
             where T : DealHubSpotModel, new();
+        DealListHubSpotModel<T> AssociatedList<T>(bool includeAssociations, long hubId, ListRequestOptions opts = null, string objectName = "contact") where T :DealHubSpotModel, new();
     }
 }

--- a/HubSpot.NET/Core/Interfaces/IHubSpotDealApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotDealApi.cs
@@ -18,6 +18,6 @@ namespace HubSpot.NET.Core.Interfaces
 
         DealRecentListHubSpotModel<T> RecentlyUpdated<T>(DealRecentRequestOptions opts = null)
             where T : DealHubSpotModel, new();
-        DealListHubSpotModel<T> AssociatedList<T>(bool includeAssociations, long hubId, ListRequestOptions opts = null, string objectName = "contact") where T :DealHubSpotModel, new();
+        DealListHubSpotModel<T> ListAssociated<T>(bool includeAssociations, long hubId, ListRequestOptions opts = null, string objectName = "contact") where T :DealHubSpotModel, new();
     }
 }


### PR DESCRIPTION
I have added two new methods to the project.

1. CreateOrUpdate Contact based on email. This allows you to send one request for both updates and creates of new contacts with the email as the identifier.

2. AssociatedLists Deals. This allows you to query all deal associated to a particular Account or Contact. 