### PR TITLE
Added constructors to ListRequestOptions to set the upper limit for deals

### DIFF
--- a/HubSpot.NET.Examples/Deals.cs
+++ b/HubSpot.NET.Examples/Deals.cs
@@ -33,7 +33,7 @@ namespace HubSpot.NET.Examples
              * Get all deals
              */
             var deals = api.Deal.List<DealHubSpotModel>(false,
-                new ListRequestOptions { PropertiesToInclude = new List<string> { "dealname", "amount" } });
+                new ListRequestOptions(250) { PropertiesToInclude = new List<string> { "dealname", "amount" } });
 
             /**
              *  Get all deals

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -73,7 +73,7 @@ namespace HubSpot.NET.Api.Deal
         {
             if (opts == null)
             {
-                opts = new ListRequestOptions();
+                opts = new ListRequestOptions(250);
             }
 
             var path = $"{new DealListHubSpotModel<T>().RouteBasePath}/deal/paged"

--- a/HubSpot.NET/Core/ListRequestOptions.cs
+++ b/HubSpot.NET/Core/ListRequestOptions.cs
@@ -9,6 +9,7 @@ namespace HubSpot.NET.Core
     public class ListRequestOptions
     {
         private int _limit = 20;
+        private readonly int _upperLimit;
 
         /// <summary>
         /// Gets or sets the number of items to return.
@@ -24,13 +25,32 @@ namespace HubSpot.NET.Core
             get => _limit;
             set
             {
-                if (value < 1 || value > 100)
+                if (value < 1 || value > _upperLimit)
                 {
                     throw new ArgumentException(
-                        $"Number of items to return must be a positive ingeteger greater than 0, and less than 100 - you provided {value}");
+                        $"Number of items to return must be a positive integer greater than 0, and less than {_upperLimit} - you provided {value}");
                 }
                 _limit = value;
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:HubSpot.NET.Core.ListRequestOptions"/> class.
+        /// </summary>
+        /// <param name="upperLimit">Upper limit for the amount of items to request for the list.</param>
+        public ListRequestOptions(int upperLimit)
+        {
+            _upperLimit = upperLimit;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:HubSpot.NET.Core.ListRequestOptions"/> class.
+        /// Sets the upper limit to 100 
+        /// </summary>
+        public ListRequestOptions()
+            : this(100)
+        {
+
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes Issue #22 and allow the ability to change the upper limit on the ListRequestOptions class. 