### PR TITLE
Removes Flurl dependency

### DIFF
--- a/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
+++ b/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
@@ -1,6 +1,5 @@
 namespace HubSpot.NET.Api.Company
 {
-    using Flurl;
     using HubSpot.NET.Api.Company.Dto;
     using HubSpot.NET.Core;
     using HubSpot.NET.Core.Abstracts;
@@ -8,9 +7,9 @@ namespace HubSpot.NET.Api.Company
     using RestSharp;
     using System;
     using System.Linq;
-	using System.Net;
+    using System.Net;
 
-	public class HubSpotCompanyApi : ApiRoutable, IHubSpotCompanyApi
+    public class HubSpotCompanyApi : ApiRoutable, IHubSpotCompanyApi
     {
         private readonly IHubSpotClient _client;
         public override string MidRoute => "/companies/v2";        
@@ -79,13 +78,15 @@ namespace HubSpot.NET.Api.Company
         {
             opts = opts ?? new ListRequestOptions();
 
-            var path = GetRoute<CompanyHubSpotModel>("companies", "paged").SetQueryParam(QueryParams.COUNT, opts.Limit);
+            string path = GetRoute<CompanyHubSpotModel>("companies", "paged");
+
+            path += $"{QueryParams.COUNT}={opts.Limit}";
 
             if (opts.PropertiesToInclude.Any())
-                path.SetQueryParam(QueryParams.PROPERTIES, opts.PropertiesToInclude);
+                path += $"{QueryParams.PROPERTIES}={opts.PropertiesToInclude}";
 
             if (opts.Offset.HasValue)
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
 
             return _client.Execute<CompanyListHubSpotModel<CompanyHubSpotModel>, ListRequestOptions>(path, opts);
         }

--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -3,8 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net;
-    using Flurl;
+    using System.Net;    
     using HubSpot.NET.Api.Contact.Dto;
     using HubSpot.NET.Core;
     using HubSpot.NET.Core.Abstracts;
@@ -156,16 +155,17 @@
         /// <returns>A list of contacts</returns>
         public ContactListHubSpotModel<ContactHubSpotModel> List(ListRequestOptions opts = null)
         {
-            opts = opts ?? new ListRequestOptions();            
+            opts = opts ?? new ListRequestOptions();
 
-            var path = GetRoute<ContactHubSpotModel>("lists", "all", "contacts","all")
-                .SetQueryParam(QueryParams.COUNT, opts.Limit);
+            string path = GetRoute<ContactHubSpotModel>("lists", "all", "contacts", "all");
+                 
+            path += $"{QueryParams.COUNT}={opts.Limit}";
 
             if (opts.PropertiesToInclude.Any())            
-                path.SetQueryParam(QueryParams.PROPERTY, opts.PropertiesToInclude);            
+                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";            
 
             if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.VID_OFFSET, opts.Offset);
+                path = path += $"{QueryParams.VID_OFFSET}={opts.Offset}";
 
             return _client.Execute<ContactListHubSpotModel<ContactHubSpotModel>, ListRequestOptions>(path, opts);           
         }
@@ -209,21 +209,22 @@
         {
             opts = opts ?? new ListRecentRequestOptions();
 
-            Url path = GetRoute<ContactHubSpotModel>("lists", "recently_updated","contacts","recent")
-                .SetQueryParam("count", opts.Limit);
+            string path = GetRoute<ContactHubSpotModel>("lists", "recently_updated", "contacts", "recent");
+
+            path += $"?{QueryParams.COUNT}={opts.Limit}";
 
             if (opts.PropertiesToInclude.Any())            
-                path.SetQueryParam(QueryParams.PROPERTY, opts.PropertiesToInclude);            
+                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";            
 
             if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.VID_OFFSET, opts.Offset);            
+                path += $"{QueryParams.VID_OFFSET}={opts.Offset}";            
 
             if (!string.IsNullOrEmpty(opts.TimeOffset))            
-                path = path.SetQueryParam(QueryParams.TIME_OFFSET, opts.TimeOffset);            
+                path += $"{QueryParams.TIME_OFFSET}={opts.TimeOffset}";            
             
-            path = path.SetQueryParam(QueryParams.PROPERTY_MODE, opts.PropertyMode)
-                        .SetQueryParam(QueryParams.FORM_SUBMISSION_MODE, opts.FormSubmissionMode)
-                        .SetQueryParam(QueryParams.SHOW_LIST_MEMBERSHIPS, opts.ShowListMemberships);
+            path += $"{QueryParams.PROPERTY_MODE}={opts.PropertyMode}" +
+                $"&{QueryParams.FORM_SUBMISSION_MODE}={opts.FormSubmissionMode}" +
+                $"&{QueryParams.SHOW_LIST_MEMBERSHIPS}={opts.ShowListMemberships}";
             
             return _client.Execute<ContactListHubSpotModel<ContactHubSpotModel>, ListRecentRequestOptions>(path, opts);
         }
@@ -232,16 +233,16 @@
         {
             opts = opts ?? new ContactSearchRequestOptions();
 
-            Url path = GetRoute<ContactHubSpotModel>("search","query")
-                .SetQueryParam("q", opts.Query)
-                .SetQueryParam(QueryParams.COUNT, opts.Limit);
+            string path = GetRoute<ContactHubSpotModel>("search", "query");
+                
+            path += $"q={opts.Query}&{QueryParams.COUNT}={opts.Limit}";
 
             if (opts.PropertiesToInclude.Any())            
-                path.SetQueryParam(QueryParams.PROPERTY, opts.PropertiesToInclude);            
+                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";            
 
 
             if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
+                path = path += $"{QueryParams.OFFSET}={opts.Offset}";            
 
             return _client.Execute<ContactSearchHubSpotModel<ContactHubSpotModel>, ContactSearchRequestOptions>(path, opts);            
         }
@@ -256,21 +257,22 @@
         {            
             opts = opts ?? new ListRecentRequestOptions();
 
-            Url path = GetRoute<ContactHubSpotModel>("lists","all","contacts","recent")
-                .SetQueryParam("count", opts.Limit);
+            string path = GetRoute<ContactHubSpotModel>("lists", "all", "contacts", "recent");
+                 
+            path += $"{QueryParams.COUNT}={opts.Limit}";
 
             if (opts.PropertiesToInclude.Any())            
-                path.SetQueryParam("property", opts.PropertiesToInclude);
+                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";
 
             if (opts.Offset.HasValue)            
-                path = path.SetQueryParam("vidOffset", opts.Offset);
+                path = path += $"{QueryParams.VID_OFFSET}={opts.Offset}";
 
             if (!string.IsNullOrEmpty(opts.TimeOffset))            
-                path = path.SetQueryParam("timeOffset", opts.TimeOffset);
+                path = path += $"{QueryParams.TIME_OFFSET}={opts.TimeOffset}";
             
-            path = path.SetQueryParam("propertyMode", opts.PropertyMode)
-                        .SetQueryParam("formSubmissionMode", opts.FormSubmissionMode)
-                        .SetQueryParam("showListMemberships", opts.ShowListMemberships);   
+            path += $"{QueryParams.PROPERTY_MODE}={opts.PropertyMode}"
+                    + $"{QueryParams.FORM_SUBMISSION_MODE}={opts.FormSubmissionMode}"
+                    + $"{QueryParams.SHOW_LIST_MEMBERSHIPS}={opts.ShowListMemberships}";   
             
             return _client.Execute<ContactListHubSpotModel<ContactHubSpotModel>, ListRecentRequestOptions>(path, opts);
         }
@@ -289,17 +291,18 @@
                 opts = new ListRequestOptions();
             }
 
-            var path = GetRoute<ContactHubSpotModel>("lists", $"{listId}", "contacts", "all").SetQueryParam(QueryParams.COUNT, opts.Limit);
+            string path = GetRoute<ContactHubSpotModel>("lists", $"{listId}", "contacts", "all");
+            path += $"{QueryParams.COUNT}={opts.Limit}";
 
 
             if (opts.PropertiesToInclude.Any())
             {
-                path.SetQueryParam(QueryParams.PROPERTY, opts.PropertiesToInclude);
+                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";
             }
 
             if (opts.Offset.HasValue)
             {
-                path = path.SetQueryParam(QueryParams.VID_OFFSET, opts.Offset);
+                path = path += $"{QueryParams.VID_OFFSET}={opts.Offset}";
             }
 
             var data = _client.Execute<ContactListHubSpotModel<ContactHubSpotModel>>(path);

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -1,15 +1,14 @@
 ﻿namespace HubSpot.NET.Api.Deal
 {
-    using System;
-    using System.Linq;
-    using System.Net;
-    using Flurl;
     using HubSpot.NET.Api.Deal.Dto;
     using HubSpot.NET.Api.Shared;
     using HubSpot.NET.Core;
     using HubSpot.NET.Core.Abstracts;
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
+    using System;
+    using System.Linq;
+    using System.Net;
 
     public class HubSpotDealApi : ApiRoutable, IHubSpotDealApi
     {
@@ -32,7 +31,7 @@
             NameTransportModel<DealHubSpotModel> model = new NameTransportModel<DealHubSpotModel>();
             model.ToPropertyTransportModel(entity);
 
-            return _client.Execute<DealHubSpotModel,NameTransportModel<DealHubSpotModel>>(GetRoute<DealHubSpotModel>(), model, Method.POST);
+            return _client.Execute<DealHubSpotModel, NameTransportModel<DealHubSpotModel>>(GetRoute<DealHubSpotModel>(), model, Method.POST);
         }
 
         /// <summary>
@@ -63,10 +62,10 @@
         /// <returns>The updated deal entity</returns>
         public DealHubSpotModel Update(DealHubSpotModel entity)
         {
-            if (entity.Id < 1)            
+            if (entity.Id < 1)
                 throw new ArgumentException("Deal entity must have an id set!");
 
-            return _client.Execute<DealHubSpotModel, DealHubSpotModel>(GetRoute<DealHubSpotModel>(entity.Id.ToString()), entity, method: Method.PUT);            
+            return _client.Execute<DealHubSpotModel, DealHubSpotModel>(GetRoute<DealHubSpotModel>(entity.Id.ToString()), entity, method: Method.PUT);
         }
 
         /// <summary>
@@ -79,16 +78,18 @@
         {
             opts = opts ?? new ListRequestOptions(250);
 
-            Url path = GetRoute<DealListHubSpotModel<DealHubSpotModel>>("deal", "paged").SetQueryParam("limit", opts.Limit);
+            string path = GetRoute<DealListHubSpotModel<DealHubSpotModel>>("deal", "paged");
 
-            if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
+            path += $"{QueryParams.LIMIT}={opts.Limit}";
 
-            if (includeAssociations)            
-                path = path.SetQueryParam(QueryParams.INCLUDE_ASSOCIATIONS, "true");            
+            if (opts.Offset.HasValue)
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
 
-            if (opts.PropertiesToInclude.Any())            
-                path = path.SetQueryParam(QueryParams.PROPERTIES, opts.PropertiesToInclude);           
+            if (includeAssociations)
+                path += $"{QueryParams.INCLUDE_ASSOCIATIONS}=true";
+
+            if (opts.PropertiesToInclude.Any())
+                path += $"{QueryParams.PROPERTIES}={opts.PropertiesToInclude}";
 
             return _client.Execute<DealListHubSpotModel<DealHubSpotModel>, ListRequestOptions>(path, opts);
         }
@@ -104,19 +105,20 @@
         /// <returns>List of deals</returns>
         public DealListHubSpotModel<DealHubSpotModel> ListAssociated(bool includeAssociations, long hubId, ListRequestOptions opts = null, string objectName = "contact")
         {
-            opts = opts ?? new ListRequestOptions();            
+            opts = opts ?? new ListRequestOptions();
 
-            Url path = GetRoute<DealListHubSpotModel<DealHubSpotModel>>("deal","associated",$"{objectName}",$"{hubId}","paged")
-            .SetQueryParam(QueryParams.LIMIT, opts.Limit);
+            string path = GetRoute<DealListHubSpotModel<DealHubSpotModel>>("deal", "associated", $"{objectName}", $"{hubId}", "paged");
 
-            if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
+            path += $"{QueryParams.LIMIT}={opts.Limit}";
 
-            if (includeAssociations)            
-                path = path.SetQueryParam(QueryParams.INCLUDE_ASSOCIATIONS, "true");            
+            if (opts.Offset.HasValue)
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
 
-            if (opts.PropertiesToInclude.Any())            
-                path = path.SetQueryParam(QueryParams.PROPERTIES, opts.PropertiesToInclude);
+            if (includeAssociations)
+                path += $"{QueryParams.INCLUDE_ASSOCIATIONS}=true";
+
+            if (opts.PropertiesToInclude.Any())
+                path += $"{QueryParams.PROPERTIES}={opts.PropertiesToInclude}";
 
             return _client.Execute<DealListHubSpotModel<DealHubSpotModel>, ListRequestOptions>(path, opts);
         }
@@ -125,7 +127,7 @@
         /// Deletes a given deal (by ID)
         /// </summary>
         /// <param name="dealId">ID of the deal</param>
-        public void Delete(long dealId) 
+        public void Delete(long dealId)
             => _client.ExecuteOnly(GetRoute<DealHubSpotModel>(dealId.ToString()), method: Method.DELETE);
 
         /// <summary>
@@ -136,22 +138,23 @@
         /// <returns>List of deals</returns>
         public DealRecentListHubSpotModel<DealHubSpotModel> RecentlyCreated(DealRecentRequestOptions opts = null)
         {
-            opts = opts ?? new DealRecentRequestOptions();            
+            opts = opts ?? new DealRecentRequestOptions();
 
-            Url path = $"{GetRoute<DealRecentListHubSpotModel<DealHubSpotModel>>()}/deal/recent/created"
-                            .SetQueryParam(QueryParams.LIMIT, opts.Limit);
+            string path = $"{GetRoute<DealRecentListHubSpotModel<DealHubSpotModel>>()}/deal/recent/created";
 
-            if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
+            path += $"{QueryParams.LIMIT}={opts.Limit}";
 
-            if (opts.IncludePropertyVersion)            
-                path = path.SetQueryParam(QueryParams.INCLUDE_PROPERTY_VERSIONS, "true");            
+            if (opts.Offset.HasValue)
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
+
+            if (opts.IncludePropertyVersion)
+                path += $"{QueryParams.INCLUDE_PROPERTY_VERSIONS}=true";
 
 
-            if (!string.IsNullOrEmpty(opts.Since))            
-                path = path.SetQueryParam(QueryParams.SINCE, opts.Since);            
+            if (!string.IsNullOrEmpty(opts.Since))
+                path += $"{QueryParams.SINCE}={opts.Since}";
 
-            return _client.Execute<DealRecentListHubSpotModel<DealHubSpotModel>, DealRecentRequestOptions>(path, opts);            
+            return _client.Execute<DealRecentListHubSpotModel<DealHubSpotModel>, DealRecentRequestOptions>(path, opts);
         }
 
         /// <summary>
@@ -162,19 +165,19 @@
         /// <returns>List of deals</returns>
         public DealRecentListHubSpotModel<DealHubSpotModel> RecentlyUpdated(DealRecentRequestOptions opts = null)
         {
-            opts = opts ?? new DealRecentRequestOptions();            
+            opts = opts ?? new DealRecentRequestOptions();
 
-            var path = GetRoute<DealRecentListHubSpotModel<DealHubSpotModel>>("deal","recent","modified").SetQueryParam(QueryParams.LIMIT, opts.Limit);
+            string path = GetRoute<DealRecentListHubSpotModel<DealHubSpotModel>>("deal", "recent", "modified");
+            path += $"{QueryParams.LIMIT}={opts.Limit}";
 
-            if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
+            if (opts.Offset.HasValue)
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
 
             if (opts.IncludePropertyVersion)
-                path = path.SetQueryParam(QueryParams.INCLUDE_PROPERTY_VERSIONS, "true");
+                path += $"{QueryParams.INCLUDE_PROPERTY_VERSIONS}=true";
 
-            if (!string.IsNullOrEmpty(opts.Since))             
-                path = path.SetQueryParam(QueryParams.SINCE, opts.Since);
-
+            if (!string.IsNullOrEmpty(opts.Since))
+                path += $"{QueryParams.SINCE}={opts.Since}";
 
             return _client.Execute<DealRecentListHubSpotModel<DealHubSpotModel>, DealRecentRequestOptions>(path, opts);
         }

--- a/HubSpot.NET/Api/EmailEvents/HubSpotEmailEventsApi.cs
+++ b/HubSpot.NET/Api/EmailEvents/HubSpotEmailEventsApi.cs
@@ -1,11 +1,10 @@
 ﻿namespace HubSpot.NET.Api.EmailEvents
 {
-	using System.Net;
-	using Flurl;
     using HubSpot.NET.Api.EmailEvents.Dto;
-	using HubSpot.NET.Core;
-	using HubSpot.NET.Core.Interfaces;
+    using HubSpot.NET.Core;
+    using HubSpot.NET.Core.Interfaces;
     using RestSharp;
+    using System.Net;
 
     public class HubSpotEmailEventsApi : IHubSpotEmailEventsApi
     {
@@ -25,7 +24,7 @@
         /// <returns>The campaign data entity or null if the compaign does not exist.</returns>
         public T GetCampaignDataById<T>(long campaignId, long appId) where T : EmailCampaignDataHubSpotModel, new()
         {
-            var path = $"{(new T()).RouteBasePath}/{campaignId}".SetQueryParam(QueryParams.APP_ID, appId);
+            var path = $"{(new T()).RouteBasePath}/{campaignId}?{QueryParams.APP_ID}={appId}";
 
             try
             {
@@ -53,13 +52,10 @@
                 opts = new EmailCampaignListRequestOptions { Limit = 250 };
             }
 
-            var path = $"{new EmailCampaignListHubSpotModel<T>().RouteBasePath}/by-id"
-                .SetQueryParam(QueryParams.LIMIT, opts.Limit);
+            var path = $"{new EmailCampaignListHubSpotModel<T>().RouteBasePath}/by-id?{QueryParams.LIMIT}={opts.Limit}";
 
-            if (!string.IsNullOrEmpty(opts.Offset))
-            {
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
-            }
+            if (!string.IsNullOrEmpty(opts.Offset))            
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
 
             var data = _client.Execute<EmailCampaignListHubSpotModel<T>>(path);
 
@@ -79,13 +75,10 @@
                 opts = new EmailCampaignListRequestOptions { Limit = 250 };
             }
 
-            var path = $"{new EmailCampaignListHubSpotModel<T>().RouteBasePath}"
-                .SetQueryParam(QueryParams.LIMIT, opts.Limit);
+            var path = $"{new EmailCampaignListHubSpotModel<T>().RouteBasePath}?{QueryParams.LIMIT}={opts.Limit}";
 
-            if (!string.IsNullOrEmpty(opts.Offset))
-            {
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
-            }
+            if (!string.IsNullOrEmpty(opts.Offset))            
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
 
             var data = _client.Execute<EmailCampaignListHubSpotModel<T>>(path);
 

--- a/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
+++ b/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
@@ -1,14 +1,13 @@
 ﻿namespace HubSpot.NET.Api.Engagement
 
 {
-    using System;
-	using System.Net;
-	using Flurl;
     using HubSpot.NET.Api.Engagement.Dto;
-	using HubSpot.NET.Core;
-	using HubSpot.NET.Core.Abstracts;
+    using HubSpot.NET.Core;
+    using HubSpot.NET.Core.Abstracts;
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
+    using System;
+    using System.Net;
 
     public class HubSpotEngagementApi : ApiRoutable, IHubSpotEngagementApi
     {
@@ -69,10 +68,10 @@
         {
             opts = opts ?? new EngagementListRequestOptions();
 
-            var path = $"{GetRoute<T>("paged")}".SetQueryParam(QueryParams.LIMIT, opts.Limit);
+            var path = $"{GetRoute<T>("paged")}?{QueryParams.LIMIT}={opts.Limit}";
 
             if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
 
             return _client.Execute<EngagementListHubSpotModel<T>, EngagementListRequestOptions>(path, opts);            
         }
@@ -86,10 +85,10 @@
         {
             opts = opts ?? new EngagementListRequestOptions();
 
-            var path = $"{GetRoute<T>()}/engagements/recent/modified".SetQueryParam(QueryParams.COUNT, opts.Limit);
+            var path = $"{GetRoute<T>()}/engagements/recent/modified?{QueryParams.COUNT}={opts.Limit}";
 
             if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
 
             return _client.Execute<EngagementListHubSpotModel<T>, EngagementListRequestOptions>(path, opts);           
         }
@@ -121,10 +120,10 @@
         {
             opts = opts ?? new EngagementListRequestOptions();
             
-            var path = $"{GetRoute<T>()}/engagements/associated/{objectType}/{objectId}/paged".SetQueryParam(QueryParams.LIMIT, opts.Limit);
+            var path = $"{GetRoute<T>()}/engagements/associated/{objectType}/{objectId}/paged?{QueryParams.LIMIT}={opts.Limit}";
 
             if (opts.Offset.HasValue)            
-                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
+                path += $"{QueryParams.OFFSET}={opts.Offset}";
 
             return _client.Execute<EngagementListHubSpotModel<T>, EngagementListRequestOptions>(path, opts);            
         }

--- a/HubSpot.NET/Api/Pipeline/HubSpotPipelinesApi.cs
+++ b/HubSpot.NET/Api/Pipeline/HubSpotPipelinesApi.cs
@@ -1,5 +1,4 @@
-﻿using Flurl;
-using HubSpot.NET.Api.Pipeline.Dto;
+﻿using HubSpot.NET.Api.Pipeline.Dto;
 using HubSpot.NET.Core.Interfaces;
 
 namespace HubSpot.NET.Api.Pipeline
@@ -23,8 +22,7 @@ namespace HubSpot.NET.Api.Pipeline
         /// <returns>The requested list</returns>
         public PipelineListHubSpotModel<T> List<T>(string objectType, string includeInactive = "EXCLUDE_DELETED") where T : PipelineHubSpotModel, new()
         {
-            Url path = $"{new PipelineListHubSpotModel<T>().RouteBasePath}/pipelines/{objectType}";
-            path.SetQueryParam("includeInactive", includeInactive);
+            string path = $"{new PipelineListHubSpotModel<T>().RouteBasePath}/pipelines/{objectType}?includeInactive={includeInactive}";
 
             var data = _client.Execute<PipelineListHubSpotModel<T>>(path, method: RestSharp.Method.GET);
 

--- a/HubSpot.NET/Core/Abstracts/ApiRoutable.cs
+++ b/HubSpot.NET/Core/Abstracts/ApiRoutable.cs
@@ -1,10 +1,7 @@
-﻿using HubSpot.NET.Api.Deal.Dto;
-using HubSpot.NET.Core.Interfaces;
+﻿using HubSpot.NET.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace HubSpot.NET.Core.Abstracts
 {

--- a/HubSpot.NET/Core/HubSpotBaseClient.cs
+++ b/HubSpot.NET/Core/HubSpotBaseClient.cs
@@ -112,8 +112,7 @@ namespace HubSpot.NET.Core
             RestRequest request = ConfigureRequestAuthentication(path, method);
            
             if(!entity.Equals(default(K)))
-                request.AddJsonBody(entity);
-            
+                request.AddJsonBody(entity);            
 
             IRestResponse response = _client.Execute(request);
 

--- a/HubSpot.NET/Core/Interfaces/IHubSpotClient.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotClient.cs
@@ -8,7 +8,6 @@ namespace HubSpot.NET.Core.Interfaces
     {
         string AppId { get; }
         string BasePath { get; }
-
         T Execute<T>(string absoluteUriPath, Method method = Method.GET) where T: new();
         T Execute<T,K>(string absoluteUriPath, K entity, Method method = Method.GET) where T: new();        
         T ExecuteMultipart<T>(string absoluteUriPath, byte[] data, string filename, Dictionary<string, string> parameters, Method method = Method.POST);

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -22,7 +22,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Flurl" Version="2.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="RestSharp" Version="106.6.9" />
   </ItemGroup>


### PR DESCRIPTION
## Description
This PR addresses issue #92 and removes the need for Flurl as a dependency.

This is only meant to be an intermediate solution before simplifying the way query strings are generated with `ListRequestOptions`. See #91 for more information

## Purpose
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [ ] I have added documentation as necessary
