### PR TITLE
Revert "Removes Flurl dependency"

### DIFF
--- a/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
+++ b/HubSpot.NET/Api/Company/HubSpotCompanyApi.cs
@@ -1,5 +1,6 @@
 namespace HubSpot.NET.Api.Company
 {
+    using Flurl;
     using HubSpot.NET.Api.Company.Dto;
     using HubSpot.NET.Core;
     using HubSpot.NET.Core.Abstracts;
@@ -7,9 +8,9 @@ namespace HubSpot.NET.Api.Company
     using RestSharp;
     using System;
     using System.Linq;
-    using System.Net;
+	using System.Net;
 
-    public class HubSpotCompanyApi : ApiRoutable, IHubSpotCompanyApi
+	public class HubSpotCompanyApi : ApiRoutable, IHubSpotCompanyApi
     {
         private readonly IHubSpotClient _client;
         public override string MidRoute => "/companies/v2";        
@@ -78,15 +79,13 @@ namespace HubSpot.NET.Api.Company
         {
             opts = opts ?? new ListRequestOptions();
 
-            string path = GetRoute<CompanyHubSpotModel>("companies", "paged");
-
-            path += $"{QueryParams.COUNT}={opts.Limit}";
+            var path = GetRoute<CompanyHubSpotModel>("companies", "paged").SetQueryParam(QueryParams.COUNT, opts.Limit);
 
             if (opts.PropertiesToInclude.Any())
-                path += $"{QueryParams.PROPERTIES}={opts.PropertiesToInclude}";
+                path.SetQueryParam(QueryParams.PROPERTIES, opts.PropertiesToInclude);
 
             if (opts.Offset.HasValue)
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
 
             return _client.Execute<CompanyListHubSpotModel<CompanyHubSpotModel>, ListRequestOptions>(path, opts);
         }

--- a/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
+++ b/HubSpot.NET/Api/Contact/HubSpotContactApi.cs
@@ -3,7 +3,8 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net;    
+    using System.Net;
+    using Flurl;
     using HubSpot.NET.Api.Contact.Dto;
     using HubSpot.NET.Core;
     using HubSpot.NET.Core.Abstracts;
@@ -155,17 +156,16 @@
         /// <returns>A list of contacts</returns>
         public ContactListHubSpotModel<ContactHubSpotModel> List(ListRequestOptions opts = null)
         {
-            opts = opts ?? new ListRequestOptions();
+            opts = opts ?? new ListRequestOptions();            
 
-            string path = GetRoute<ContactHubSpotModel>("lists", "all", "contacts", "all");
-                 
-            path += $"{QueryParams.COUNT}={opts.Limit}";
+            var path = GetRoute<ContactHubSpotModel>("lists", "all", "contacts","all")
+                .SetQueryParam(QueryParams.COUNT, opts.Limit);
 
             if (opts.PropertiesToInclude.Any())            
-                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";            
+                path.SetQueryParam(QueryParams.PROPERTY, opts.PropertiesToInclude);            
 
             if (opts.Offset.HasValue)            
-                path = path += $"{QueryParams.VID_OFFSET}={opts.Offset}";
+                path = path.SetQueryParam(QueryParams.VID_OFFSET, opts.Offset);
 
             return _client.Execute<ContactListHubSpotModel<ContactHubSpotModel>, ListRequestOptions>(path, opts);           
         }
@@ -209,22 +209,21 @@
         {
             opts = opts ?? new ListRecentRequestOptions();
 
-            string path = GetRoute<ContactHubSpotModel>("lists", "recently_updated", "contacts", "recent");
-
-            path += $"?{QueryParams.COUNT}={opts.Limit}";
+            Url path = GetRoute<ContactHubSpotModel>("lists", "recently_updated","contacts","recent")
+                .SetQueryParam("count", opts.Limit);
 
             if (opts.PropertiesToInclude.Any())            
-                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";            
+                path.SetQueryParam(QueryParams.PROPERTY, opts.PropertiesToInclude);            
 
             if (opts.Offset.HasValue)            
-                path += $"{QueryParams.VID_OFFSET}={opts.Offset}";            
+                path = path.SetQueryParam(QueryParams.VID_OFFSET, opts.Offset);            
 
             if (!string.IsNullOrEmpty(opts.TimeOffset))            
-                path += $"{QueryParams.TIME_OFFSET}={opts.TimeOffset}";            
+                path = path.SetQueryParam(QueryParams.TIME_OFFSET, opts.TimeOffset);            
             
-            path += $"{QueryParams.PROPERTY_MODE}={opts.PropertyMode}" +
-                $"&{QueryParams.FORM_SUBMISSION_MODE}={opts.FormSubmissionMode}" +
-                $"&{QueryParams.SHOW_LIST_MEMBERSHIPS}={opts.ShowListMemberships}";
+            path = path.SetQueryParam(QueryParams.PROPERTY_MODE, opts.PropertyMode)
+                        .SetQueryParam(QueryParams.FORM_SUBMISSION_MODE, opts.FormSubmissionMode)
+                        .SetQueryParam(QueryParams.SHOW_LIST_MEMBERSHIPS, opts.ShowListMemberships);
             
             return _client.Execute<ContactListHubSpotModel<ContactHubSpotModel>, ListRecentRequestOptions>(path, opts);
         }
@@ -233,16 +232,16 @@
         {
             opts = opts ?? new ContactSearchRequestOptions();
 
-            string path = GetRoute<ContactHubSpotModel>("search", "query");
-                
-            path += $"q={opts.Query}&{QueryParams.COUNT}={opts.Limit}";
+            Url path = GetRoute<ContactHubSpotModel>("search","query")
+                .SetQueryParam("q", opts.Query)
+                .SetQueryParam(QueryParams.COUNT, opts.Limit);
 
             if (opts.PropertiesToInclude.Any())            
-                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";            
+                path.SetQueryParam(QueryParams.PROPERTY, opts.PropertiesToInclude);            
 
 
             if (opts.Offset.HasValue)            
-                path = path += $"{QueryParams.OFFSET}={opts.Offset}";            
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
 
             return _client.Execute<ContactSearchHubSpotModel<ContactHubSpotModel>, ContactSearchRequestOptions>(path, opts);            
         }
@@ -257,22 +256,21 @@
         {            
             opts = opts ?? new ListRecentRequestOptions();
 
-            string path = GetRoute<ContactHubSpotModel>("lists", "all", "contacts", "recent");
-                 
-            path += $"{QueryParams.COUNT}={opts.Limit}";
+            Url path = GetRoute<ContactHubSpotModel>("lists","all","contacts","recent")
+                .SetQueryParam("count", opts.Limit);
 
             if (opts.PropertiesToInclude.Any())            
-                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";
+                path.SetQueryParam("property", opts.PropertiesToInclude);
 
             if (opts.Offset.HasValue)            
-                path = path += $"{QueryParams.VID_OFFSET}={opts.Offset}";
+                path = path.SetQueryParam("vidOffset", opts.Offset);
 
             if (!string.IsNullOrEmpty(opts.TimeOffset))            
-                path = path += $"{QueryParams.TIME_OFFSET}={opts.TimeOffset}";
+                path = path.SetQueryParam("timeOffset", opts.TimeOffset);
             
-            path += $"{QueryParams.PROPERTY_MODE}={opts.PropertyMode}"
-                    + $"{QueryParams.FORM_SUBMISSION_MODE}={opts.FormSubmissionMode}"
-                    + $"{QueryParams.SHOW_LIST_MEMBERSHIPS}={opts.ShowListMemberships}";   
+            path = path.SetQueryParam("propertyMode", opts.PropertyMode)
+                        .SetQueryParam("formSubmissionMode", opts.FormSubmissionMode)
+                        .SetQueryParam("showListMemberships", opts.ShowListMemberships);   
             
             return _client.Execute<ContactListHubSpotModel<ContactHubSpotModel>, ListRecentRequestOptions>(path, opts);
         }
@@ -291,18 +289,17 @@
                 opts = new ListRequestOptions();
             }
 
-            string path = GetRoute<ContactHubSpotModel>("lists", $"{listId}", "contacts", "all");
-            path += $"{QueryParams.COUNT}={opts.Limit}";
+            var path = GetRoute<ContactHubSpotModel>("lists", $"{listId}", "contacts", "all").SetQueryParam(QueryParams.COUNT, opts.Limit);
 
 
             if (opts.PropertiesToInclude.Any())
             {
-                path += $"{QueryParams.PROPERTY}={opts.PropertiesToInclude}";
+                path.SetQueryParam(QueryParams.PROPERTY, opts.PropertiesToInclude);
             }
 
             if (opts.Offset.HasValue)
             {
-                path = path += $"{QueryParams.VID_OFFSET}={opts.Offset}";
+                path = path.SetQueryParam(QueryParams.VID_OFFSET, opts.Offset);
             }
 
             var data = _client.Execute<ContactListHubSpotModel<ContactHubSpotModel>>(path);

--- a/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
+++ b/HubSpot.NET/Api/Deal/HubSpotDealApi.cs
@@ -1,14 +1,15 @@
 ﻿namespace HubSpot.NET.Api.Deal
 {
+    using System;
+    using System.Linq;
+    using System.Net;
+    using Flurl;
     using HubSpot.NET.Api.Deal.Dto;
     using HubSpot.NET.Api.Shared;
     using HubSpot.NET.Core;
     using HubSpot.NET.Core.Abstracts;
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
-    using System;
-    using System.Linq;
-    using System.Net;
 
     public class HubSpotDealApi : ApiRoutable, IHubSpotDealApi
     {
@@ -31,7 +32,7 @@
             NameTransportModel<DealHubSpotModel> model = new NameTransportModel<DealHubSpotModel>();
             model.ToPropertyTransportModel(entity);
 
-            return _client.Execute<DealHubSpotModel, NameTransportModel<DealHubSpotModel>>(GetRoute<DealHubSpotModel>(), model, Method.POST);
+            return _client.Execute<DealHubSpotModel,NameTransportModel<DealHubSpotModel>>(GetRoute<DealHubSpotModel>(), model, Method.POST);
         }
 
         /// <summary>
@@ -62,10 +63,10 @@
         /// <returns>The updated deal entity</returns>
         public DealHubSpotModel Update(DealHubSpotModel entity)
         {
-            if (entity.Id < 1)
+            if (entity.Id < 1)            
                 throw new ArgumentException("Deal entity must have an id set!");
 
-            return _client.Execute<DealHubSpotModel, DealHubSpotModel>(GetRoute<DealHubSpotModel>(entity.Id.ToString()), entity, method: Method.PUT);
+            return _client.Execute<DealHubSpotModel, DealHubSpotModel>(GetRoute<DealHubSpotModel>(entity.Id.ToString()), entity, method: Method.PUT);            
         }
 
         /// <summary>
@@ -78,18 +79,16 @@
         {
             opts = opts ?? new ListRequestOptions(250);
 
-            string path = GetRoute<DealListHubSpotModel<DealHubSpotModel>>("deal", "paged");
+            Url path = GetRoute<DealListHubSpotModel<DealHubSpotModel>>("deal", "paged").SetQueryParam("limit", opts.Limit);
 
-            path += $"{QueryParams.LIMIT}={opts.Limit}";
+            if (opts.Offset.HasValue)            
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
 
-            if (opts.Offset.HasValue)
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
+            if (includeAssociations)            
+                path = path.SetQueryParam(QueryParams.INCLUDE_ASSOCIATIONS, "true");            
 
-            if (includeAssociations)
-                path += $"{QueryParams.INCLUDE_ASSOCIATIONS}=true";
-
-            if (opts.PropertiesToInclude.Any())
-                path += $"{QueryParams.PROPERTIES}={opts.PropertiesToInclude}";
+            if (opts.PropertiesToInclude.Any())            
+                path = path.SetQueryParam(QueryParams.PROPERTIES, opts.PropertiesToInclude);           
 
             return _client.Execute<DealListHubSpotModel<DealHubSpotModel>, ListRequestOptions>(path, opts);
         }
@@ -105,20 +104,19 @@
         /// <returns>List of deals</returns>
         public DealListHubSpotModel<DealHubSpotModel> ListAssociated(bool includeAssociations, long hubId, ListRequestOptions opts = null, string objectName = "contact")
         {
-            opts = opts ?? new ListRequestOptions();
+            opts = opts ?? new ListRequestOptions();            
 
-            string path = GetRoute<DealListHubSpotModel<DealHubSpotModel>>("deal", "associated", $"{objectName}", $"{hubId}", "paged");
+            Url path = GetRoute<DealListHubSpotModel<DealHubSpotModel>>("deal","associated",$"{objectName}",$"{hubId}","paged")
+            .SetQueryParam(QueryParams.LIMIT, opts.Limit);
 
-            path += $"{QueryParams.LIMIT}={opts.Limit}";
+            if (opts.Offset.HasValue)            
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
 
-            if (opts.Offset.HasValue)
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
+            if (includeAssociations)            
+                path = path.SetQueryParam(QueryParams.INCLUDE_ASSOCIATIONS, "true");            
 
-            if (includeAssociations)
-                path += $"{QueryParams.INCLUDE_ASSOCIATIONS}=true";
-
-            if (opts.PropertiesToInclude.Any())
-                path += $"{QueryParams.PROPERTIES}={opts.PropertiesToInclude}";
+            if (opts.PropertiesToInclude.Any())            
+                path = path.SetQueryParam(QueryParams.PROPERTIES, opts.PropertiesToInclude);
 
             return _client.Execute<DealListHubSpotModel<DealHubSpotModel>, ListRequestOptions>(path, opts);
         }
@@ -127,7 +125,7 @@
         /// Deletes a given deal (by ID)
         /// </summary>
         /// <param name="dealId">ID of the deal</param>
-        public void Delete(long dealId)
+        public void Delete(long dealId) 
             => _client.ExecuteOnly(GetRoute<DealHubSpotModel>(dealId.ToString()), method: Method.DELETE);
 
         /// <summary>
@@ -138,23 +136,22 @@
         /// <returns>List of deals</returns>
         public DealRecentListHubSpotModel<DealHubSpotModel> RecentlyCreated(DealRecentRequestOptions opts = null)
         {
-            opts = opts ?? new DealRecentRequestOptions();
+            opts = opts ?? new DealRecentRequestOptions();            
 
-            string path = $"{GetRoute<DealRecentListHubSpotModel<DealHubSpotModel>>()}/deal/recent/created";
+            Url path = $"{GetRoute<DealRecentListHubSpotModel<DealHubSpotModel>>()}/deal/recent/created"
+                            .SetQueryParam(QueryParams.LIMIT, opts.Limit);
 
-            path += $"{QueryParams.LIMIT}={opts.Limit}";
+            if (opts.Offset.HasValue)            
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
 
-            if (opts.Offset.HasValue)
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
-
-            if (opts.IncludePropertyVersion)
-                path += $"{QueryParams.INCLUDE_PROPERTY_VERSIONS}=true";
+            if (opts.IncludePropertyVersion)            
+                path = path.SetQueryParam(QueryParams.INCLUDE_PROPERTY_VERSIONS, "true");            
 
 
-            if (!string.IsNullOrEmpty(opts.Since))
-                path += $"{QueryParams.SINCE}={opts.Since}";
+            if (!string.IsNullOrEmpty(opts.Since))            
+                path = path.SetQueryParam(QueryParams.SINCE, opts.Since);            
 
-            return _client.Execute<DealRecentListHubSpotModel<DealHubSpotModel>, DealRecentRequestOptions>(path, opts);
+            return _client.Execute<DealRecentListHubSpotModel<DealHubSpotModel>, DealRecentRequestOptions>(path, opts);            
         }
 
         /// <summary>
@@ -165,19 +162,19 @@
         /// <returns>List of deals</returns>
         public DealRecentListHubSpotModel<DealHubSpotModel> RecentlyUpdated(DealRecentRequestOptions opts = null)
         {
-            opts = opts ?? new DealRecentRequestOptions();
+            opts = opts ?? new DealRecentRequestOptions();            
 
-            string path = GetRoute<DealRecentListHubSpotModel<DealHubSpotModel>>("deal", "recent", "modified");
-            path += $"{QueryParams.LIMIT}={opts.Limit}";
+            var path = GetRoute<DealRecentListHubSpotModel<DealHubSpotModel>>("deal","recent","modified").SetQueryParam(QueryParams.LIMIT, opts.Limit);
 
-            if (opts.Offset.HasValue)
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
+            if (opts.Offset.HasValue)            
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
 
             if (opts.IncludePropertyVersion)
-                path += $"{QueryParams.INCLUDE_PROPERTY_VERSIONS}=true";
+                path = path.SetQueryParam(QueryParams.INCLUDE_PROPERTY_VERSIONS, "true");
 
-            if (!string.IsNullOrEmpty(opts.Since))
-                path += $"{QueryParams.SINCE}={opts.Since}";
+            if (!string.IsNullOrEmpty(opts.Since))             
+                path = path.SetQueryParam(QueryParams.SINCE, opts.Since);
+
 
             return _client.Execute<DealRecentListHubSpotModel<DealHubSpotModel>, DealRecentRequestOptions>(path, opts);
         }

--- a/HubSpot.NET/Api/EmailEvents/HubSpotEmailEventsApi.cs
+++ b/HubSpot.NET/Api/EmailEvents/HubSpotEmailEventsApi.cs
@@ -1,10 +1,11 @@
 ﻿namespace HubSpot.NET.Api.EmailEvents
 {
+	using System.Net;
+	using Flurl;
     using HubSpot.NET.Api.EmailEvents.Dto;
-    using HubSpot.NET.Core;
-    using HubSpot.NET.Core.Interfaces;
+	using HubSpot.NET.Core;
+	using HubSpot.NET.Core.Interfaces;
     using RestSharp;
-    using System.Net;
 
     public class HubSpotEmailEventsApi : IHubSpotEmailEventsApi
     {
@@ -24,7 +25,7 @@
         /// <returns>The campaign data entity or null if the compaign does not exist.</returns>
         public T GetCampaignDataById<T>(long campaignId, long appId) where T : EmailCampaignDataHubSpotModel, new()
         {
-            var path = $"{(new T()).RouteBasePath}/{campaignId}?{QueryParams.APP_ID}={appId}";
+            var path = $"{(new T()).RouteBasePath}/{campaignId}".SetQueryParam(QueryParams.APP_ID, appId);
 
             try
             {
@@ -52,10 +53,13 @@
                 opts = new EmailCampaignListRequestOptions { Limit = 250 };
             }
 
-            var path = $"{new EmailCampaignListHubSpotModel<T>().RouteBasePath}/by-id?{QueryParams.LIMIT}={opts.Limit}";
+            var path = $"{new EmailCampaignListHubSpotModel<T>().RouteBasePath}/by-id"
+                .SetQueryParam(QueryParams.LIMIT, opts.Limit);
 
-            if (!string.IsNullOrEmpty(opts.Offset))            
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
+            if (!string.IsNullOrEmpty(opts.Offset))
+            {
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
+            }
 
             var data = _client.Execute<EmailCampaignListHubSpotModel<T>>(path);
 
@@ -75,10 +79,13 @@
                 opts = new EmailCampaignListRequestOptions { Limit = 250 };
             }
 
-            var path = $"{new EmailCampaignListHubSpotModel<T>().RouteBasePath}?{QueryParams.LIMIT}={opts.Limit}";
+            var path = $"{new EmailCampaignListHubSpotModel<T>().RouteBasePath}"
+                .SetQueryParam(QueryParams.LIMIT, opts.Limit);
 
-            if (!string.IsNullOrEmpty(opts.Offset))            
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
+            if (!string.IsNullOrEmpty(opts.Offset))
+            {
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
+            }
 
             var data = _client.Execute<EmailCampaignListHubSpotModel<T>>(path);
 

--- a/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
+++ b/HubSpot.NET/Api/Engagement/HubSpotEngagementApi.cs
@@ -1,13 +1,14 @@
 ﻿namespace HubSpot.NET.Api.Engagement
 
 {
+    using System;
+	using System.Net;
+	using Flurl;
     using HubSpot.NET.Api.Engagement.Dto;
-    using HubSpot.NET.Core;
-    using HubSpot.NET.Core.Abstracts;
+	using HubSpot.NET.Core;
+	using HubSpot.NET.Core.Abstracts;
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
-    using System;
-    using System.Net;
 
     public class HubSpotEngagementApi : ApiRoutable, IHubSpotEngagementApi
     {
@@ -68,10 +69,10 @@
         {
             opts = opts ?? new EngagementListRequestOptions();
 
-            var path = $"{GetRoute<T>("paged")}?{QueryParams.LIMIT}={opts.Limit}";
+            var path = $"{GetRoute<T>("paged")}".SetQueryParam(QueryParams.LIMIT, opts.Limit);
 
             if (opts.Offset.HasValue)            
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
 
             return _client.Execute<EngagementListHubSpotModel<T>, EngagementListRequestOptions>(path, opts);            
         }
@@ -85,10 +86,10 @@
         {
             opts = opts ?? new EngagementListRequestOptions();
 
-            var path = $"{GetRoute<T>()}/engagements/recent/modified?{QueryParams.COUNT}={opts.Limit}";
+            var path = $"{GetRoute<T>()}/engagements/recent/modified".SetQueryParam(QueryParams.COUNT, opts.Limit);
 
             if (opts.Offset.HasValue)            
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);
 
             return _client.Execute<EngagementListHubSpotModel<T>, EngagementListRequestOptions>(path, opts);           
         }
@@ -120,10 +121,10 @@
         {
             opts = opts ?? new EngagementListRequestOptions();
             
-            var path = $"{GetRoute<T>()}/engagements/associated/{objectType}/{objectId}/paged?{QueryParams.LIMIT}={opts.Limit}";
+            var path = $"{GetRoute<T>()}/engagements/associated/{objectType}/{objectId}/paged".SetQueryParam(QueryParams.LIMIT, opts.Limit);
 
             if (opts.Offset.HasValue)            
-                path += $"{QueryParams.OFFSET}={opts.Offset}";
+                path = path.SetQueryParam(QueryParams.OFFSET, opts.Offset);            
 
             return _client.Execute<EngagementListHubSpotModel<T>, EngagementListRequestOptions>(path, opts);            
         }

--- a/HubSpot.NET/Api/Pipeline/HubSpotPipelinesApi.cs
+++ b/HubSpot.NET/Api/Pipeline/HubSpotPipelinesApi.cs
@@ -1,4 +1,5 @@
-﻿using HubSpot.NET.Api.Pipeline.Dto;
+﻿using Flurl;
+using HubSpot.NET.Api.Pipeline.Dto;
 using HubSpot.NET.Core.Interfaces;
 
 namespace HubSpot.NET.Api.Pipeline
@@ -22,7 +23,8 @@ namespace HubSpot.NET.Api.Pipeline
         /// <returns>The requested list</returns>
         public PipelineListHubSpotModel<T> List<T>(string objectType, string includeInactive = "EXCLUDE_DELETED") where T : PipelineHubSpotModel, new()
         {
-            string path = $"{new PipelineListHubSpotModel<T>().RouteBasePath}/pipelines/{objectType}?includeInactive={includeInactive}";
+            Url path = $"{new PipelineListHubSpotModel<T>().RouteBasePath}/pipelines/{objectType}";
+            path.SetQueryParam("includeInactive", includeInactive);
 
             var data = _client.Execute<PipelineListHubSpotModel<T>>(path, method: RestSharp.Method.GET);
 

--- a/HubSpot.NET/Core/Abstracts/ApiRoutable.cs
+++ b/HubSpot.NET/Core/Abstracts/ApiRoutable.cs
@@ -1,7 +1,10 @@
-﻿using HubSpot.NET.Core.Interfaces;
+﻿using HubSpot.NET.Api.Deal.Dto;
+using HubSpot.NET.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace HubSpot.NET.Core.Abstracts
 {

--- a/HubSpot.NET/Core/HubSpotBaseClient.cs
+++ b/HubSpot.NET/Core/HubSpotBaseClient.cs
@@ -112,7 +112,8 @@ namespace HubSpot.NET.Core
             RestRequest request = ConfigureRequestAuthentication(path, method);
            
             if(!entity.Equals(default(K)))
-                request.AddJsonBody(entity);            
+                request.AddJsonBody(entity);
+            
 
             IRestResponse response = _client.Execute(request);
 

--- a/HubSpot.NET/Core/Interfaces/IHubSpotClient.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotClient.cs
@@ -8,6 +8,7 @@ namespace HubSpot.NET.Core.Interfaces
     {
         string AppId { get; }
         string BasePath { get; }
+
         T Execute<T>(string absoluteUriPath, Method method = Method.GET) where T: new();
         T Execute<T,K>(string absoluteUriPath, K entity, Method method = Method.GET) where T: new();        
         T ExecuteMultipart<T>(string absoluteUriPath, byte[] data, string filename, Dictionary<string, string> parameters, Method method = Method.POST);

--- a/HubSpot.NET/HubSpot.NET.csproj
+++ b/HubSpot.NET/HubSpot.NET.csproj
@@ -22,6 +22,7 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Flurl" Version="2.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="RestSharp" Version="106.6.9" />
   </ItemGroup>


### PR DESCRIPTION
Reverts hubspot-net/HubSpot.NET#93

I suggest rollback for this merge/pull request. For removing the Flurl dependency just replace the SetQueryParam extension with own implementation of the same functionality. It will be easier to maintain and also fix errors like missing escaping, missing ampersands, etc. . I have marked just one example of missing ampersand in the commit 5a4f646, but there are many more.