### PR TITLE
Issue #102 - HubSpotOAuthApi Authorize and Refresh not returning tokens

### DIFF
--- a/HubSpot.NET/Api/OAuth/HubSpotOAuthApi.cs
+++ b/HubSpot.NET/Api/OAuth/HubSpotOAuthApi.cs
@@ -103,19 +103,15 @@
                 JsonSerializer = new FakeSerializer()
             };
 
+            request.AddHeader("Content-Type", "application/x-www-form-urlencoded");
+
             Dictionary<string, string> jsonPreStringPairs = JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(model));
 
             StringBuilder bodyBuilder = new StringBuilder();
             foreach(KeyValuePair<string,string> pair in jsonPreStringPairs)
             {
-                if (bodyBuilder.Length > 0)
-                { bodyBuilder.Append("&"); }
-
-                bodyBuilder.Append($"{pair.Key}={pair.Value}");
+                request.AddParameter(pair.Key, pair.Value);
             }
-
-            request.AddJsonBody(bodyBuilder.ToString());
-            request.AddHeader("ContentType", "application/x-www-form-urlencoded");
 
             if (builder.Length > 0)
                 request.AddQueryParameter("scope", builder.ToString());


### PR DESCRIPTION
## Description
Bug fix for Issue #102 

## Purpose
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests to prove that what I have fixed or added does indeed work
- [ ] I have added documentation as necessary
