### PR TITLE
Fixed issue # 108 : Engagement Type cannot be null

### DIFF
--- a/HubSpot.NET/Api/Engagement/Dto/EngagementHubSpotModel.cs
+++ b/HubSpot.NET/Api/Engagement/Dto/EngagementHubSpotModel.cs
@@ -49,7 +49,7 @@ namespace HubSpot.NET.Api.Engagement.Dto
     public class EngagementHubSpotEngagementModel
     {
         [DataMember(Name = "id")]
-        public long? Id { get; set; }
+        public long Id { get; set; }
 
         [DataMember(Name = "type")]
         public string Type { get;set; }

--- a/HubSpot.NET/Core/HubSpotBaseClient.cs
+++ b/HubSpot.NET/Core/HubSpotBaseClient.cs
@@ -4,6 +4,7 @@ namespace HubSpot.NET.Core
     using HubSpot.NET.Core.Interfaces;
     using HubSpot.NET.Core.Serializers;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
     using RestSharp;
     using System.Collections.Generic;
 
@@ -110,9 +111,15 @@ namespace HubSpot.NET.Core
         private T SendReceiveRequest<T,K>(string path, Method method, K entity) where T: new()
         {
             RestRequest request = ConfigureRequestAuthentication(path, method);
-           
-            if(!entity.Equals(default(K)))
-                request.AddJsonBody(entity);            
+
+            var json = JsonConvert.SerializeObject(entity, new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                NullValueHandling = NullValueHandling.Ignore
+            });
+
+            if (!entity.Equals(default(K)))
+                request.AddJsonBody(json);
 
             IRestResponse response = _client.Execute(request);
 
@@ -179,7 +186,6 @@ namespace HubSpot.NET.Core
                     break;
             }
 
-            request.JsonSerializer = new NewtonsoftRestSharpSerializer();            
             return request;
         }
 


### PR DESCRIPTION
## Description
Fixed the JSON serialization bug that was causing the error "Engagement type cannot be null" while creating an engagement, as highlighted in issue # 108.

## Purpose
- [x] Bugfix (non-breaking change which fixes an issue)